### PR TITLE
MAJOR refactor to Hook and dependents

### DIFF
--- a/Assets/Scripts/Audio Scripts/PlayerAudio.cs
+++ b/Assets/Scripts/Audio Scripts/PlayerAudio.cs
@@ -20,12 +20,12 @@ public class PlayerAudio : MonoBehaviour, Input.IHookActions
     [SerializeField] private PlayerController playerController;
     [SerializeField] private GrapplingHook hook;
     private bool lastFrameIsGrounded = false;
-    
+
     private Input input;
-    
+
     private bool playingGrappleAudio = false;
     public HookAudioState hookState = HookAudioState.Base;
- 
+
 
     // Start is called before the first frame update
     void Start()
@@ -35,7 +35,7 @@ public class PlayerAudio : MonoBehaviour, Input.IHookActions
     // Update is called once per frame
     void Update()
     {
-        if (playerController.IsGrounded() && !lastFrameIsGrounded && playerController.Body.velocity.y <= 20.0f) 
+        if (playerController.IsGrounded() && !lastFrameIsGrounded && playerController.Body.velocity.y <= 20.0f)
         {
             //play land sound
             PlayGroundedSound();
@@ -45,11 +45,11 @@ public class PlayerAudio : MonoBehaviour, Input.IHookActions
         else
         {//else add the result to the bool array, with circular index 
             lastFrameIsGrounded = playerController.IsGrounded();
-           
+
         }
 
         HookAudioStateMachine();
-        if (hook.GetIsPlayerPullingIn() && !playerController.IsGrounded() && !playingGrappleAudio)
+        if (hook.State == GrapplingHook.HookState.Pulling && !playerController.IsGrounded() && !playingGrappleAudio)
         {
             playingGrappleAudio = true;
         }
@@ -57,8 +57,8 @@ public class PlayerAudio : MonoBehaviour, Input.IHookActions
         {
             playingGrappleAudio = false;
         }
-      
-        
+
+
     }
 
     private void HookAudioStateMachine()
@@ -66,26 +66,26 @@ public class PlayerAudio : MonoBehaviour, Input.IHookActions
         switch (hookState)
         {
             case HookAudioState.Base:
-                if (hook.GetIsPlayerPullingIn() && !playerController.IsGrounded() && !playingGrappleAudio)
+                if (hook.State == GrapplingHook.HookState.Pulling && !playerController.IsGrounded() && !playingGrappleAudio)
                 {
-                    hookState = HookAudioState.StartRapel; 
+                    hookState = HookAudioState.StartRapel;
                 }
                 break;
             case HookAudioState.StartRapel:
                 source.clip = hookRappelSfx;
                 source.Play();
                 hookState = HookAudioState.Rappeling;
-                break; 
+                break;
             case HookAudioState.Rappeling:
                 if (playerController.IsGrounded())
                 {
                     source.Stop();
-                    
+
                     hookState = HookAudioState.Base;
                 }
                 break;
-            
-        } 
+
+        }
     }
     private void OnEnable()
     {
@@ -138,8 +138,8 @@ public class PlayerAudio : MonoBehaviour, Input.IHookActions
 
 public enum HookAudioState
 {
-    StartRapel, 
-   Rappeling, 
-   StopRappel, 
-   Base, 
+    StartRapel,
+    Rappeling,
+    StopRappel,
+    Base,
 }

--- a/Assets/Scripts/Player/GrapplingHook.cs
+++ b/Assets/Scripts/Player/GrapplingHook.cs
@@ -235,6 +235,9 @@ namespace SkyReach.Player
             originalPlayerGravity = player.Body.gravityScale;
             player.Body.gravityScale = gravityOverride;
 
+            // fire event
+            hookPullAction?.Invoke();
+
             // change state
             State = HookState.Pulling;
         }

--- a/Assets/Scripts/Player/GrapplingHook.cs
+++ b/Assets/Scripts/Player/GrapplingHook.cs
@@ -16,40 +16,40 @@ namespace SkyReach.Player
     ///
     /// - Victor (10/19/2022)
     /// </summary>
-    [RequireComponent(typeof(Rigidbody2D))]
+    [RequireComponent(typeof(Rigidbody2D), typeof(CircleCollider2D))]
     public class GrapplingHook : MonoBehaviour, Input.IHookActions
     {
-        [Header("Hook Properties")] [SerializeField]
-        private float fireSpeed = 40f;
-
-        [SerializeField] private float retractForce = 250f;
-        [SerializeField] private float baseDistance = 1f;
-        [SerializeField] private float maxDistance = 15f;
+        [Header("Hook Properties")]
+        [SerializeField] private float fireSpeed = 500f;
+        [SerializeField] private float retractSpeed = 1800f;
+        [SerializeField] private float baseDistance = 25f;
+        [SerializeField] private float maxDistance = 150f;
         [SerializeField] private float cooldownLength = 1f;
+        [SerializeField] private float gravityOverride = 0f;
+        [SerializeField] private bool canPullOnRetract = true;
         [SerializeField] private LayerMask hookMask;
 
-        [Header("Player Reference")] [SerializeField]
+        [Header("Player Reference")]
+        [SerializeField]
         private PlayerController player;
 
         // exposed properties
-        public bool IsAttached
-        {
-            get { return isAttached; }
-        }
+        public HookState State { get; private set; } = HookState.Idle;
 
         // internal variables
         private Vector2 aimTarget;
-        private Vector2 lastHorizontalFacingDirection;
-        private bool isRetracting;
-        private bool isAttached;
-        private bool isInCooldown;
         private Rigidbody2D hookBody;
+        private CircleCollider2D hookCollider;
+        private Rigidbody2D attachedBody;
         private Input input;
         private int hookingLayer;
+        private float originalPlayerGravity;
+        private float cooldownTimer;
+        private bool isFiring;
 
         //helper variable to determine when player is being pulled by hook
         private bool isPullingPlayer = false;
-        public static event Action hook;
+        public static event Action hookPullAction;
 
 
         public void OnEnable()
@@ -78,6 +78,7 @@ namespace SkyReach.Player
             }
 
             hookBody = GetComponent<Rigidbody2D>();
+            hookCollider = GetComponent<CircleCollider2D>();
         }
 
         public void Start()
@@ -91,129 +92,187 @@ namespace SkyReach.Player
 
             input.Enable();
 
-            // disable hook until fired
-            StopHook();
-
             // set hooking layer
             hookingLayer = LayerMask.NameToLayer("HookingPlayer");
         }
 
-        public void Update()
-        {
-            // rotate hook in a circle around the player
-            // circle is radius baseDistance
-            // rotation is towards aimTarget
-            if (!hookBody.simulated)
-            {
-                Vector2 direction = (Vector2)UnityEngine.Camera.main.ScreenToWorldPoint(aimTarget) -
-                                    (Vector2)player.transform.position;
-                float angle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg;
-                transform.rotation = Quaternion.AngleAxis(angle, Vector3.forward);
-                transform.position = (Vector2)player.transform.position + direction.normalized * baseDistance;
-            }
-        }
-
         public void FixedUpdate()
         {
-            // if hook is not attached to anything
-            if (!isAttached)
+            switch (State)
             {
-                if (!isRetracting)
-                {
-                    if (Vector2.Distance(hookBody.position, player.Body.position) >= maxDistance)
+                case HookState.Firing:
+                    // Check if hook can attach
+                    Collider2D[] colliders = Physics2D.OverlapCircleAll(transform.position, hookCollider.radius, hookMask);
+                    if (colliders.Length > 0)
                     {
-                        isRetracting = true;
+                        Attach(colliders[0].attachedRigidbody);
                     }
-                }
-                else
-                {
-                    if (!hookBody.IsTouching(player.Collider))
-                    {
-                        // move hook towards player
-                        hookBody.velocity = (player.Body.position - hookBody.position).normalized * fireSpeed;
-                    }
-                    else StopHook();
-                }
 
-                // check if hook can attach to something
-                if (hookBody.IsTouchingLayers(hookMask))
-                {
-                    isAttached = true;
-                    hook?.Invoke(); // invoke hook event for stat tracking
-                    hookBody.velocity = Vector2.zero;
-                    player.gameObject.layer = hookingLayer;
-                }
-            }
-            else
-            {
-                if (!hookBody.IsTouching(player.Collider))
-                {
-                    isPullingPlayer = true;
+                    // if trying to fire hook, but hook is already out, finish it prematurely
+                    if (isFiring)
+                    {
+                        Finish();
+                    }
+
+                    // if hook reaches max distance, retract it
+                    if (isFiring || Vector2.Distance(transform.position, player.transform.position) >= maxDistance)
+                    {
+                        Retract();
+                    }
+                    break;
+
+                case HookState.Retracting:
+
+                    // if trying to fire hook, but hook is already out, finish it prematurely
+                    if (isFiring)
+                    {
+                        Finish();
+                    }
+
+                    // check if hook has reached player
+                    if (player.Collider.IsTouching(hookCollider))
+                    {
+                        Finish();
+                        break;
+                    }
+
+                    // try to attach to a target if canPullOnRetract is true
+                    if (canPullOnRetract)
+                    {
+                        // Check if hook can attach
+                        Collider2D[] cols = Physics2D.OverlapCircleAll(transform.position, hookCollider.radius, hookMask);
+                        if (cols.Length > 0)
+                        {
+                            Attach(cols[0].attachedRigidbody);
+                            break;
+                        }
+                    }
+
+                    // move hook towards player
+                    Vector2 direction = player.Body.position - hookBody.position;
+                    hookBody.velocity = direction.normalized * retractSpeed;
+                    break;
+
+                case HookState.Pulling:
+                    // if trying to fire hook, but hook is already out, finish it prematurely
+                    if (isFiring)
+                    {
+                        Finish();
+                    }
+
+                    // if hook is attached to a moving body, move the hook with it
+                    hookBody.velocity = attachedBody?.velocity ?? Vector2.zero;
+
+                    // check if player has reached hook
+                    if (player.Collider.IsTouching(hookCollider))
+                    {
+                        Finish();
+                        break;
+                    }
+
                     // move player towards hook
-                    player.Body.AddForce((hookBody.position - player.Body.position).normalized * retractForce);
-                }
-                else
-                {
-                    isPullingPlayer = false;
-                    StopHook();
-                }
+                    Vector2 pullDirection = hookBody.position - player.Body.position;
+                    player.Body.AddForce(pullDirection.normalized * retractSpeed);
+                    break;
+
+                case HookState.Cooldown:
+                    // check if cooldown is over
+                    if (cooldownTimer <= 0)
+                    {
+                        State = HookState.Idle;
+                        break;
+                    }
+
+                    cooldownTimer -= Time.fixedDeltaTime;
+
+                    // move hook to player
+                    hookBody.position = player.Body.position;
+                    break;
+
+                case HookState.Idle:
+
+                    // move and rotate hook to rotate around player in aim direction at base distance
+                    Vector2 aimDirection = (Vector2)UnityEngine.Camera.main.ScreenToWorldPoint(aimTarget) - player.Body.position;
+                    hookBody.position = player.Body.position + aimDirection.normalized * baseDistance;
+                    transform.rotation = Quaternion.Euler(0, 0, Mathf.Atan2(aimDirection.y, aimDirection.x) * Mathf.Rad2Deg);
+
+                    // check if hook is being fired
+                    if (isFiring)
+                    {
+                        Fire();
+                    }
+                    break;
             }
         }
 
-        public void StartHook()
+        private void Fire()
         {
-            // get aim direction by converting screen position to world position
-            Vector2 aimDirection = (Vector2)transform.position - player.Body.position;
+            // get direction to fire hook
+            Vector2 directionToFire = (Vector2)UnityEngine.Camera.main.ScreenToWorldPoint(aimTarget) - player.Body.position;
 
-            isRetracting = false;
-            isAttached = false;
-            hookBody.simulated = true;
-            hookBody.position = transform.position;
-            hookBody.velocity = aimDirection.normalized * fireSpeed;
+            // set body properties
+            hookBody.position = player.Body.position + (Vector2)directionToFire.normalized * baseDistance;
+            hookBody.velocity = directionToFire.normalized * fireSpeed;
+
+            // change state
+            State = HookState.Firing;
+            isFiring = false;
         }
 
-        public void StopHook()
+        private void Retract()
         {
-            isRetracting = false;
-            isAttached = false;
+            // change state
+            State = HookState.Retracting;
+        }
+
+        private void Attach(Rigidbody2D body)
+        {
+            // move hook with attached body if it is moving, otherwise keep it still
+            hookBody.velocity = body?.velocity ?? Vector2.zero;
+            attachedBody = body;
+
+            // set player gravity
+            originalPlayerGravity = player.Body.gravityScale;
+            player.Body.gravityScale = gravityOverride;
+
+            // change state
+            State = HookState.Pulling;
+        }
+
+        private void Finish()
+        {
+            // reset player gravity and update original gravity
+            player.Body.gravityScale = originalPlayerGravity;
+            originalPlayerGravity = player.Body.gravityScale;
+
+            // detach hook from any bodies
+            attachedBody = null;
             hookBody.velocity = Vector2.zero;
-            hookBody.simulated = false;
-            player.gameObject.layer = 0; // default layer
-            StopCoroutine(Cooldown());
-            StartCoroutine(Cooldown());
+            hookBody.position = player.Body.position;
+
+            // start cooldown
+            cooldownTimer = cooldownLength;
+
+            State = HookState.Cooldown;
         }
 
         void Input.IHookActions.OnFire(InputAction.CallbackContext context)
         {
-            if (context.started && !isInCooldown)
-            {
-                if (!hookBody.simulated)
-                {
-                    StartHook();
-                }
-                else
-                {
-                    StopHook();
-                }
-            }
+            isFiring = context.ReadValueAsButton();
         }
-
 
         void Input.IHookActions.OnAim(InputAction.CallbackContext context)
         {
             aimTarget = context.ReadValue<Vector2>();
         }
 
-        public bool GetIsPlayerPullingIn()
+        public enum HookState
         {
-            return isPullingPlayer;
-        }
-
-        IEnumerator Cooldown()
-        {
-            isInCooldown = true;
-            yield return new WaitForSeconds(cooldownLength);
-            isInCooldown = false;
+            Idle,
+            Firing,
+            Retracting,
+            Pulling,
+            Cooldown
         }
     }
 }

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -69,8 +69,6 @@ namespace SkyReach.Player
             input.Disable();
         }
 
-
-
         public void FixedUpdate()
         {
             // set gravity scale.
@@ -86,7 +84,7 @@ namespace SkyReach.Player
             Vector2 relativeVelocity = Body.velocity;
 
             // if the ground collider is a moving rigidbody, remove its velocity from the player's velocity
-            Rigidbody2D groundBody = groundCollider.GetComponent<Rigidbody2D>();
+            Rigidbody2D groundBody = groundCollider?.GetComponent<Rigidbody2D>();
             if (groundBody != null)
             {
                 relativeVelocity -= groundBody.velocity;

--- a/Assets/Scripts/Statistics/StatisticsData.cs
+++ b/Assets/Scripts/Statistics/StatisticsData.cs
@@ -8,113 +8,113 @@ using UnityEngine.SceneManagement;
 
 
 public class StatisticsData : MonoBehaviour
+{
+    public static StatisticsData Instance;
+    private int jumps = 0;
+    private int numHooks = 0;
+    private int playerDeath = 0;
+    private int enemiesKilled = 0;
+    private float bestRunTime = Single.MaxValue;
+
+
+    private void Awake()
     {
-        public static StatisticsData Instance;
-        private int jumps = 0;
-        private int numHooks = 0;
-        private int playerDeath = 0;
-        private int enemiesKilled = 0;
-        private float bestRunTime = Single.MaxValue;
-        
-        
-        private void Awake()
+        if (Instance != null && Instance != this)
+            Destroy(this);
+        else
         {
-            if (Instance != null && Instance != this)
-                Destroy(this);
-            else
-            {
-                Instance = this;
-                DontDestroyOnLoad(this);
-            }
-               
+            Instance = this;
+            DontDestroyOnLoad(this);
         }
 
-        private void Update()
-        {
-            if (Input.GetKeyDown(KeyCode.Q))
-            {
-                SceneManager.LoadScene(0);
-            }
-        }
+    }
 
-        public int getJumps()
+    private void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Q))
         {
-            return PlayerPrefs.GetInt("Jumps");
-        }
-
-        public int getDeaths()
-        {
-            return PlayerPrefs.GetInt("Deaths"); ;
-        }
-
-        public int getHooks()
-        {
-            return PlayerPrefs.GetInt("Hooks");
-        }
-
-      
-        public int GetEnemiesKilled()
-        {
-            return PlayerPrefs.GetInt("Enemies Killed");
-        }
-        
-        public float GetBestRunTime()
-        {
-            return PlayerPrefs.GetFloat("BestRunTime");
-        }
-
-        void OnEnable()
-        {
-            //method that increase jumps
-            PlayerController.jump += setJumps;
-            GrapplingHook.hook += setHooks;
-            GameManager.OnPlayerDeath += setDeaths; 
-            
-        }
-
-        void OnDisable()
-        {
-            //unsubscribe 
-            PlayerController.jump -= setJumps;
-            GrapplingHook.hook -= setHooks;
-            GameManager.OnPlayerDeath -= setDeaths; 
-
-        }
-
-        public void SetBestRunTime(float latestRunTime)
-        {
-           
-            
-            if(latestRunTime < PlayerPrefs.GetFloat("BestRunTime"))
-                PlayerPrefs.SetFloat("BestRunTime", latestRunTime);
-            
-            Debug.Log(PlayerPrefs.GetFloat("BestRunTime") + " is the new best run time");
-        }
-        void setJumps()
-        {
-            jumps++;
-            PlayerPrefs.SetInt("Jumps", jumps);
-            //Debug.Log("Jump triggered!");
-        }
-
-        void setDeaths()
-        {
-            playerDeath++;
-            PlayerPrefs.SetInt("Deaths", playerDeath);
-        }
-
-        void setHooks()
-        {
-            numHooks++;
-            PlayerPrefs.SetInt("Hooks", numHooks);
-            //Debug.Log("Number of times hooked: " + numHooks);
-        }
-        
-        void setEnemiesKilled()
-        {
-            enemiesKilled++;
-            PlayerPrefs.SetInt("Enemies Killed", enemiesKilled);
+            SceneManager.LoadScene(0);
         }
     }
+
+    public int getJumps()
+    {
+        return PlayerPrefs.GetInt("Jumps");
+    }
+
+    public int getDeaths()
+    {
+        return PlayerPrefs.GetInt("Deaths"); ;
+    }
+
+    public int getHooks()
+    {
+        return PlayerPrefs.GetInt("Hooks");
+    }
+
+
+    public int GetEnemiesKilled()
+    {
+        return PlayerPrefs.GetInt("Enemies Killed");
+    }
+
+    public float GetBestRunTime()
+    {
+        return PlayerPrefs.GetFloat("BestRunTime");
+    }
+
+    void OnEnable()
+    {
+        //method that increase jumps
+        PlayerController.jump += setJumps;
+        GrapplingHook.hookPullAction += setHooks;
+        GameManager.OnPlayerDeath += setDeaths;
+
+    }
+
+    void OnDisable()
+    {
+        //unsubscribe 
+        PlayerController.jump -= setJumps;
+        GrapplingHook.hookPullAction -= setHooks;
+        GameManager.OnPlayerDeath -= setDeaths;
+
+    }
+
+    public void SetBestRunTime(float latestRunTime)
+    {
+
+
+        if (latestRunTime < PlayerPrefs.GetFloat("BestRunTime"))
+            PlayerPrefs.SetFloat("BestRunTime", latestRunTime);
+
+        Debug.Log(PlayerPrefs.GetFloat("BestRunTime") + " is the new best run time");
+    }
+    void setJumps()
+    {
+        jumps++;
+        PlayerPrefs.SetInt("Jumps", jumps);
+        //Debug.Log("Jump triggered!");
+    }
+
+    void setDeaths()
+    {
+        playerDeath++;
+        PlayerPrefs.SetInt("Deaths", playerDeath);
+    }
+
+    void setHooks()
+    {
+        numHooks++;
+        PlayerPrefs.SetInt("Hooks", numHooks);
+        //Debug.Log("Number of times hooked: " + numHooks);
+    }
+
+    void setEnemiesKilled()
+    {
+        enemiesKilled++;
+        PlayerPrefs.SetInt("Enemies Killed", enemiesKilled);
+    }
+}
 
 


### PR DESCRIPTION
This branch is aimed at tacking the following existing problems with the grappling hook system:

- The hook pull can be too "swingy", unpredictable movement
- The hook fires in incorrect direction occasionally
- There are many scripts that read the state of the Hook

The solutions in place are:
- A gravity override parameter that allows the player to be affected less by gravity when being pulled, or not at all. This was the primary cause of swinging
- A restructure in how the hook controller processes input
- A plethora of boolean values scrapped in favor of a HookState enum. This is a public readable value, so any scripts that depend on the state of the player can read it much more easily.
- The hook now acts as a finite state diagram as opposed to a decision tree, to match the use of HookState. Both achieve the same results, while the finite state diagram looks arguably much more readable and pleasing